### PR TITLE
feat: add smooth levelbar slider as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ volbar --stop-daemon
 |--------|--------|---------|-------------|
 | `--size` | small, medium, large | medium | Window size |
 | `--placement` | center, top, bottom, left, right, top-left, top-right, bottom-left, bottom-right | center | Screen position |
-| `--slider` | blocks, dots, line | blocks | Slider style |
+| `--slider` | smooth, blocks, dots, line | smooth | Slider style |
 | `--theme` | theme name or `auto` | default | CSS theme |
 | `--timeout` | milliseconds | 2000 | Display duration |
 | `--poll-interval` | milliseconds | 200 | Daemon check interval |
@@ -68,7 +68,11 @@ volbar --stop-daemon
 
 ### Slider Styles
 
+`smooth` (default) is a continuous, CSS-styled filled bar. The legacy
+character styles render the level with text glyphs:
+
 ```
+smooth   ▰▰▰▰▰▱▱▱▱▱  (continuous filled bar)
 blocks   █████░░░░░
 dots     ●●●●●○○○○○
 line     ━━━━━─────
@@ -142,13 +146,18 @@ Create `~/.config/volbar/themes/mytheme.css`:
 }
 
 label#icon { color: #00ff00; }
-label#slider { color: #00ff00; }
+label#slider { color: #00ff00; }                /* legacy character styles */
 label#percentage { color: #ffffff; }
+
+/* smooth slider (default) */
+levelbar#slider trough { background-color: alpha(#00ff00, 0.25); }
+levelbar#slider block.filled { background-color: #00ff00; }
 
 /* Muted state */
 label#icon.muted,
 label#slider.muted,
 label#percentage.muted { color: #ff0000; }
+levelbar#slider.muted block.filled { background-color: #ff0000; }
 ```
 
 Then use with: `volbar --show --theme mytheme`

--- a/themes/bl-red.css
+++ b/themes/bl-red.css
@@ -31,6 +31,21 @@ label#slider.muted {
     color: #757575;
 }
 
+levelbar#slider trough {
+    background-color: alpha(#f44336, 0.25);
+    border-radius: 6px;
+    min-height: 8px;
+}
+
+levelbar#slider block.filled {
+    background-color: #f44336;
+    border-radius: 6px;
+}
+
+levelbar#slider.muted block.filled {
+    background-color: #757575;
+}
+
 label#percentage {
     color: #ef9a9a;
     font-weight: bold;

--- a/themes/catppuccin.css
+++ b/themes/catppuccin.css
@@ -26,6 +26,21 @@ label#slider.muted {
     color: #f38ba8;
 }
 
+levelbar#slider trough {
+    background-color: alpha(#89b4fa, 0.25);
+    border-radius: 6px;
+    min-height: 8px;
+}
+
+levelbar#slider block.filled {
+    background-color: #89b4fa;
+    border-radius: 6px;
+}
+
+levelbar#slider.muted block.filled {
+    background-color: #f38ba8;
+}
+
 label#percentage {
     color: #cdd6f4;
 }

--- a/themes/cyberpunk.css
+++ b/themes/cyberpunk.css
@@ -33,6 +33,21 @@ label#slider.muted {
     text-shadow: 0 0 8px rgba(255, 0, 85, 0.7);
 }
 
+levelbar#slider trough {
+    background-color: alpha(#00ffff, 0.25);
+    border-radius: 6px;
+    min-height: 8px;
+}
+
+levelbar#slider block.filled {
+    background-color: #00ffff;
+    border-radius: 6px;
+}
+
+levelbar#slider.muted block.filled {
+    background-color: #ff0055;
+}
+
 label#percentage {
     color: #ffff00;
     text-shadow: 0 0 10px rgba(255, 255, 0, 0.8);

--- a/themes/default.css
+++ b/themes/default.css
@@ -26,6 +26,21 @@ label#slider.muted {
     color: #bf616a;
 }
 
+levelbar#slider trough {
+    background-color: alpha(#8fa1b3, 0.25);
+    border-radius: 6px;
+    min-height: 8px;
+}
+
+levelbar#slider block.filled {
+    background-color: #8fa1b3;
+    border-radius: 6px;
+}
+
+levelbar#slider.muted block.filled {
+    background-color: #bf616a;
+}
+
 label#percentage {
     color: #c0c5ce;
 }

--- a/themes/dracula.css
+++ b/themes/dracula.css
@@ -26,6 +26,21 @@ label#slider.muted {
     color: #ff5555;
 }
 
+levelbar#slider trough {
+    background-color: alpha(#8be9fd, 0.25);
+    border-radius: 6px;
+    min-height: 8px;
+}
+
+levelbar#slider block.filled {
+    background-color: #8be9fd;
+    border-radius: 6px;
+}
+
+levelbar#slider.muted block.filled {
+    background-color: #ff5555;
+}
+
 label#percentage {
     color: #50fa7b;
     font-weight: bold;

--- a/themes/dragula.css
+++ b/themes/dragula.css
@@ -28,6 +28,21 @@ label#slider.muted {
     color: #4a4a4a;
 }
 
+levelbar#slider trough {
+    background-color: alpha(#cc0000, 0.25);
+    border-radius: 6px;
+    min-height: 8px;
+}
+
+levelbar#slider block.filled {
+    background-color: #cc0000;
+    border-radius: 6px;
+}
+
+levelbar#slider.muted block.filled {
+    background-color: #4a4a4a;
+}
+
 label#percentage {
     color: #ff4444;
     font-weight: bold;

--- a/themes/gruvbox.css
+++ b/themes/gruvbox.css
@@ -26,6 +26,21 @@ label#slider.muted {
     color: #fb4934;
 }
 
+levelbar#slider trough {
+    background-color: alpha(#83a598, 0.25);
+    border-radius: 6px;
+    min-height: 8px;
+}
+
+levelbar#slider block.filled {
+    background-color: #83a598;
+    border-radius: 6px;
+}
+
+levelbar#slider.muted block.filled {
+    background-color: #fb4934;
+}
+
 label#percentage {
     color: #ebdbb2;
 }

--- a/themes/neon-green.css
+++ b/themes/neon-green.css
@@ -33,6 +33,21 @@ label#slider.muted {
     text-shadow: 0 0 8px rgba(255, 0, 0, 0.7);
 }
 
+levelbar#slider trough {
+    background-color: alpha(#00ff41, 0.25);
+    border-radius: 6px;
+    min-height: 8px;
+}
+
+levelbar#slider block.filled {
+    background-color: #00ff41;
+    border-radius: 6px;
+}
+
+levelbar#slider.muted block.filled {
+    background-color: #ff0000;
+}
+
 label#percentage {
     color: #39ff14;
     text-shadow: 0 0 10px rgba(57, 255, 20, 0.8);

--- a/themes/nord.css
+++ b/themes/nord.css
@@ -26,6 +26,21 @@ label#slider.muted {
     color: #bf616a;
 }
 
+levelbar#slider trough {
+    background-color: alpha(#81a1c1, 0.25);
+    border-radius: 6px;
+    min-height: 8px;
+}
+
+levelbar#slider block.filled {
+    background-color: #81a1c1;
+    border-radius: 6px;
+}
+
+levelbar#slider.muted block.filled {
+    background-color: #bf616a;
+}
+
 label#percentage {
     color: #d8dee9;
 }

--- a/themes/solarized-dark.css
+++ b/themes/solarized-dark.css
@@ -26,6 +26,21 @@ label#slider.muted {
     color: #dc322f;
 }
 
+levelbar#slider trough {
+    background-color: alpha(#2aa198, 0.25);
+    border-radius: 6px;
+    min-height: 8px;
+}
+
+levelbar#slider block.filled {
+    background-color: #2aa198;
+    border-radius: 6px;
+}
+
+levelbar#slider.muted block.filled {
+    background-color: #dc322f;
+}
+
 label#percentage {
     color: #93a1a1;
     font-weight: bold;

--- a/themes/tokyo-night.css
+++ b/themes/tokyo-night.css
@@ -27,6 +27,21 @@ label#slider.muted {
     color: #f7768e;
 }
 
+levelbar#slider trough {
+    background-color: alpha(#7dcfff, 0.25);
+    border-radius: 6px;
+    min-height: 8px;
+}
+
+levelbar#slider block.filled {
+    background-color: #7dcfff;
+    border-radius: 6px;
+}
+
+levelbar#slider.muted block.filled {
+    background-color: #f7768e;
+}
+
 label#percentage {
     color: #9ece6a;
     font-weight: bold;

--- a/themes/vibrant-blue.css
+++ b/themes/vibrant-blue.css
@@ -31,6 +31,21 @@ label#slider.muted {
     color: #ef5350;
 }
 
+levelbar#slider trough {
+    background-color: alpha(#2196f3, 0.25);
+    border-radius: 6px;
+    min-height: 8px;
+}
+
+levelbar#slider block.filled {
+    background-color: #2196f3;
+    border-radius: 6px;
+}
+
+levelbar#slider.muted block.filled {
+    background-color: #ef5350;
+}
+
 label#percentage {
     color: #90caf9;
     font-weight: bold;

--- a/themes/vibrant-brown.css
+++ b/themes/vibrant-brown.css
@@ -31,6 +31,21 @@ label#slider.muted {
     color: #e57373;
 }
 
+levelbar#slider trough {
+    background-color: alpha(#8d6e63, 0.25);
+    border-radius: 6px;
+    min-height: 8px;
+}
+
+levelbar#slider block.filled {
+    background-color: #8d6e63;
+    border-radius: 6px;
+}
+
+levelbar#slider.muted block.filled {
+    background-color: #e57373;
+}
+
 label#percentage {
     color: #d7ccc8;
     font-weight: bold;

--- a/themes/vibrant-green.css
+++ b/themes/vibrant-green.css
@@ -31,6 +31,21 @@ label#slider.muted {
     color: #ef5350;
 }
 
+levelbar#slider trough {
+    background-color: alpha(#4caf50, 0.25);
+    border-radius: 6px;
+    min-height: 8px;
+}
+
+levelbar#slider block.filled {
+    background-color: #4caf50;
+    border-radius: 6px;
+}
+
+levelbar#slider.muted block.filled {
+    background-color: #ef5350;
+}
+
 label#percentage {
     color: #a5d6a7;
     font-weight: bold;

--- a/themes/vibrant-orange.css
+++ b/themes/vibrant-orange.css
@@ -31,6 +31,21 @@ label#slider.muted {
     color: #f44336;
 }
 
+levelbar#slider trough {
+    background-color: alpha(#ff9800, 0.25);
+    border-radius: 6px;
+    min-height: 8px;
+}
+
+levelbar#slider block.filled {
+    background-color: #ff9800;
+    border-radius: 6px;
+}
+
+levelbar#slider.muted block.filled {
+    background-color: #f44336;
+}
+
 label#percentage {
     color: #ffcc80;
     font-weight: bold;

--- a/volbar
+++ b/volbar
@@ -260,6 +260,21 @@ label#slider.muted {
     color: #bf616a;
 }
 
+levelbar#slider trough {
+    background-color: rgba(143, 161, 179, 0.25);
+    border-radius: 6px;
+    min-height: 8px;
+}
+
+levelbar#slider block.filled {
+    background-color: #8fa1b3;
+    border-radius: 6px;
+}
+
+levelbar#slider.muted block.filled {
+    background-color: #bf616a;
+}
+
 label#percentage {
     color: #c0c5ce;
 }
@@ -340,6 +355,21 @@ label#slider.muted {{
     color: {muted_color};
 }}
 
+levelbar#slider trough {{
+    background-color: alpha({accent}, 0.25);
+    border-radius: 6px;
+    min-height: 8px;
+}}
+
+levelbar#slider block.filled {{
+    background-color: {accent};
+    border-radius: 6px;
+}}
+
+levelbar#slider.muted block.filled {{
+    background-color: {muted_color};
+}}
+
 label#percentage {{
     color: {fg};
 }}
@@ -399,7 +429,7 @@ class VolumeWindow(Gtk.Window):
     ICONS = {'muted': '🔇', 'low': '🔈', 'medium': '🔉', 'high': '🔊'}
     
     def __init__(self, size='medium', placement='center', show_icon=True, 
-                 show_percent=True, slider='blocks', theme='default', debug=False):
+                 show_percent=True, slider='smooth', theme='default', debug=False):
         super().__init__()
         
         self.size_preset = SIZES[size]
@@ -483,10 +513,24 @@ class VolumeWindow(Gtk.Window):
             box.pack_start(self.icon_label, False, False, 0)
         
         # Slider (center, expands)
-        self.slider_label = Gtk.Label()
-        self.slider_label.set_name('slider')
-        self.slider_label.set_halign(Gtk.Align.CENTER)
-        box.pack_start(self.slider_label, True, True, 0)
+        # 'smooth' uses a native LevelBar (continuous, CSS-styled);
+        # the legacy character styles (blocks/dots/line) use a Label.
+        if self.slider_type == 'smooth':
+            self.slider_widget = Gtk.LevelBar()
+            self.slider_widget.set_name('slider')
+            self.slider_widget.set_mode(Gtk.LevelBarMode.CONTINUOUS)
+            self.slider_widget.set_min_value(0)
+            self.slider_widget.set_max_value(100)
+            self.slider_widget.set_value(0)
+            self.slider_widget.set_size_request(120, -1)
+            self.slider_widget.set_halign(Gtk.Align.CENTER)
+            self.slider_widget.set_valign(Gtk.Align.CENTER)
+            box.pack_start(self.slider_widget, True, True, 0)
+        else:
+            self.slider_widget = Gtk.Label()
+            self.slider_widget.set_name('slider')
+            self.slider_widget.set_halign(Gtk.Align.CENTER)
+            box.pack_start(self.slider_widget, True, True, 0)
         
         # Percent (right)
         if self.show_percent_flag:
@@ -571,14 +615,17 @@ class VolumeWindow(Gtk.Window):
             else:
                 ctx.remove_class('muted')
         
-        blocks = volume // 10
-        slider_func = SLIDERS.get(self.slider_type, SLIDERS['blocks'])
-        slider = slider_func(blocks)
-        
-        self.slider_label.set_markup(
-            f'<span font_desc="monospace {font_size}" letter_spacing="0">{slider}</span>'
-        )
-        ctx = self.slider_label.get_style_context()
+        if self.slider_type == 'smooth':
+            # Continuous fill at full 0-100 resolution
+            self.slider_widget.set_value(volume)
+        else:
+            blocks = volume // 10
+            slider_func = SLIDERS.get(self.slider_type, SLIDERS['blocks'])
+            slider = slider_func(blocks)
+            self.slider_widget.set_markup(
+                f'<span font_desc="monospace {font_size}" letter_spacing="0">{slider}</span>'
+            )
+        ctx = self.slider_widget.get_style_context()
         if muted:
             ctx.add_class('muted')
         else:
@@ -614,14 +661,16 @@ def print_version():
 def list_sliders():
     """List available slider styles"""
     print("Available slider styles:\n")
-    
+
     volume = 50
     blocks = volume // 10
-    
+
+    print(f"  {'smooth':<15} (continuous filled bar — default)")
+    print("  ── legacy character styles ──")
     for name, slider_func in SLIDERS.items():
         slider = slider_func(blocks)
         print(f"  {name:<15} {slider}")
-    
+
     print(f"\nUsage: volbar --show --slider SLIDER_NAME")
     print(f"Example: volbar --show --slider line")
 
@@ -709,7 +758,7 @@ def test_themes(args):
             placement=args.get('placement', 'center'),
             show_icon=args.get('icon', True),
             show_percent=args.get('percent', True),
-            slider=args.get('slider', 'blocks'),
+            slider=args.get('slider', 'smooth'),
             theme=theme,
             debug=args.get('debug', False)
         )
@@ -742,7 +791,7 @@ Options:
                            
   --icon on|off           Show volume icon (default: on)
   --percent on|off        Show percentage (default: on)
-  --slider TYPE           blocks, dots, line (default: blocks)
+  --slider TYPE           smooth, blocks, dots, line (default: smooth)
   --theme NAME            Theme name or 'auto' for wallpaper colors (default: default)
   --timeout MS            Display timeout in milliseconds (default: 2000)
   --poll-interval MS      Volume check interval for daemon (default: 200)
@@ -782,7 +831,7 @@ def parse_args():
         'placement': 'center',
         'icon': True,
         'percent': True,
-        'slider': 'blocks',
+        'slider': 'smooth',
         'theme': 'default',
         'timeout': 2000,
         'poll_interval': 200,

--- a/volbar.1
+++ b/volbar.1
@@ -22,7 +22,7 @@ Show volume icon (default: on)
 Show percentage (default: on)
 .TP
 .BR \-\-slider " \fITYPE\fR"
-Slider style: blocks, dots, line (default: blocks)
+Slider style: smooth, blocks, dots, line (default: smooth)
 .TP
 .BR \-\-theme " \fINAME\fR"
 Theme name from ~/.config/volbar/themes/ or 'auto' for Mabox wallpaper colors (default: default)
@@ -73,8 +73,11 @@ Display help message
 Display version information
 .SH SLIDER STYLES
 .TP
+.B smooth
+Continuous filled bar, styled via CSS (default)
+.TP
 .B blocks
-█████░░░░░ (default)
+█████░░░░░
 .TP
 .B dots
 ●●●●●○○○○○
@@ -101,9 +104,13 @@ label#icon { color: #00ff00; }
 label#slider { color: #00ff00; }
 label#percentage { color: #ffffff; }
 
+levelbar#slider trough { background-color: alpha(#00ff00, 0.25); }
+levelbar#slider block.filled { background-color: #00ff00; }
+
 label#icon.muted,
 label#slider.muted,
 label#percentage.muted { color: #ff0000; }
+levelbar#slider.muted block.filled { background-color: #ff0000; }
 .fi
 .RE
 .SH EXAMPLES


### PR DESCRIPTION
## What

Replaces the chunky unicode character-grid slider with a native `Gtk.LevelBar` in continuous mode as the new default (`--slider smooth`). The bar fills at full 0–100 resolution (the old one quantized to `volume // 10` — only 11 states) and is styled entirely via CSS.

The legacy `blocks`/`dots`/`line` styles remain selectable as a character mode.

## Theming

Themes drive the new bar through `levelbar#slider trough` / `block.filled` rules, reusing each theme's existing slider and muted colors. All 15 bundled themes, both embedded CSS blocks (`DEFAULT_CSS` + auto-theme), `README.md`, and `volbar.1` updated.

## Tested

Rendered on PipeWire/pactl across default, nord, cyberpunk, dracula themes plus legacy character fallback — no GTK CSS warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)